### PR TITLE
packagegroup-arago*: set PACKAGE_ARCH before inherit packagegroup

### DIFF
--- a/meta-arago-distro/recipes-connectivity/openssl/openssl_1.0.2d.bbappend
+++ b/meta-arago-distro/recipes-connectivity/openssl/openssl_1.0.2d.bbappend
@@ -18,9 +18,6 @@ RDEPENDS_${PN}_class-target += "cryptodev-module"
 CRYPTODEV_AFALG_PATCHES = " \
 	file://0001-Add-AF_ALG-interface-support-to-OpenSSL.patch \
 	file://0004-Sample-AF_ALG-openssl.cnf.patch \
-	file://0001-eng_cryptodev.c-update-to-cryptodev-1.6.patch \
-	file://0009-eng_cryptodev-Add-SHA224-initialization-to-cryptodev.patch \
-	file://0011-cryptodev-Add-AES-CBC-CTR-modes-for-128-192-256-bit-.patch \
 "
 
 SRC_URI += "${CRYPTODEV_AFALG_PATCHES}"

--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-base-tisdk-server-extra.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-base-tisdk-server-extra.bb
@@ -3,9 +3,9 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
 PR = "r1"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 ARAGO_LIBNL = "\
     libnl-route \

--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-base.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-base.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "Basic task to get a device booting"
 LICENSE = "MIT"
 PR = "r7"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 ARAGO_ALSA_BASE = "\
     alsa-lib \

--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-console.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-console.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "Extended task to get more basic and console apps"
 LICENSE = "MIT"
 PR = "r10"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 # alsa-utils-alsamixer depends on ncurses
 ARAGO_ALSA_EXTRA = "\

--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-gst-sdk-target.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-gst-sdk-target.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "Task to build and install header and libs in sdk"
 LICENSE = "MIT"
 PR = "r10"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 GST_010_DEPS = " \
     gstreamer-dev \

--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-gst.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-gst.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "Task to add gstreamer and gstreamer plugins"
 LICENSE = "MIT"
 PR = "r13"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 GST_010_DEPS = " \
     gstreamer \

--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-qte.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-qte.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "Task to add Qt embedded related packages"
 LICENSE = "MIT"
 PR = "r9"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 QT4_SGX_SUPPORT = "\
     qt4-embedded-plugin-gfxdriver-gfxpvregl \

--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-test.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-test.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "Extended task to get System Test specific apps"
 LICENSE = "MIT"
 PR = "r29"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 ARAGO_TEST = "\
     bonnie++ \

--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-addons-sdk-host.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-addons-sdk-host.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "Task to install sources for additional utilities/demos for SDKs"
 LICENSE = "MIT"
 PR = "r10"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 UTILS = " \
     am-sysinfo-src \

--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-addons-sdk-target.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-addons-sdk-target.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "Task to install headers and libraries related to addons into the 
 LICENSE = "MIT"
 PR = "r9"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 UTILS = "libdrm-dev"
 

--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-addons.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-addons.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "Task to install additional utilities/demos for SDKs"
 LICENSE = "MIT"
 PR = "r26"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 UTILS = " \
     am-sysinfo \

--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-amsdk-sdk-host.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-amsdk-sdk-host.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "Task to install additional scripts and applications into the SDK"
 LICENSE = "MIT"
 PR = "r22"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 # Choose the kernel and u-boot recipe sources to use
 

--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-amsdk.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-amsdk.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "Task to install additional packages only used in the Arago SDK"
 LICENSE = "MIT"
 PR = "r10"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 # Out of Box Experience (OOBE)
 OOBE = ""

--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-connectivity-sdk-host.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-connectivity-sdk-host.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "Task to install wlan and bluetooth sources into the SDK"
 LICENSE = "MIT"
 PR = "r11"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 FIRMWARE_AND_DRIVERS_SRC = "\
     ti-compat-wireless-wl18xx-src \

--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-connectivity-sdk-target.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-connectivity-sdk-target.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "Task to install wireless headers and libraries into the SDK"
 LICENSE = "MIT"
 PR = "r7"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 BLUETOOTH_STACK = "\
     bluez4-dev \

--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-connectivity.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-connectivity.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "Task to install wireless packages into the target FS"
 LICENSE = "MIT"
 PR = "r32"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 # WLAN support packages.
 # These are the packages that all platforms use for WLAN support

--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-crypto-sdk-host.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-crypto-sdk-host.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "Task to install crypto sources in SDK"
 LICENSE = "MIT"
 PR = "r6"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 CRYPTO_RDEPENDS = ""
 

--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-crypto-sdk-target.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-crypto-sdk-target.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "Task to install crypto dev packages in SDK"
 LICENSE = "MIT"
 PR = "r4"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 CRYPTO_API = ""
 CRYPTO_API_ti33x = "cryptodev-module-dev"

--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-crypto.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-crypto.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "Task to install crypto packages into target FS"
 LICENSE = "MIT"
 PR = "r6"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 # Add openssl-misc to get the openssl.cnf file which is
 # needed for "openssl req" and to avoid warnings.

--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-graphics-sdk-host.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-graphics-sdk-host.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "Task to install graphics sources in SDK"
 LICENSE = "MIT"
 PR = "r0"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 GRAPHICS_RDEPENDS = ""
 

--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-graphics-sdk-target.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-graphics-sdk-target.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "Task to install graphics binaries on sdk target"
 LICENSE = "MIT"
 PR = "r4"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 GRAPHICS_RDEPENDS = ""
 

--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-graphics.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-graphics.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "Task to install graphics binaries"
 LICENSE = "MIT"
 PR = "r8"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 GRAPHICS_WESTON = "\
     weston \

--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-matrix-sdk-host.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-matrix-sdk-host.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "Task to install Matrix v2 and associated applications sources in 
 LICENSE = "MIT"
 PR = "r4"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 MATRIX_GUI = " \
     matrix-gui-browser-src \

--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-matrix.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-matrix.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "Task to include Matrix v2"
 LICENSE = "MIT"
 PR = "r42"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 MATRIX_ESSENTIALS = "        \
     matrix-gui               \

--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-multimedia-sdk-host.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-multimedia-sdk-host.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "Task to add multimedia related sources into the SDK"
 LICENSE = "MIT"
 PR = "r7"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 MULTIMEDIA = ""
 

--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-multimedia-sdk-target.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-multimedia-sdk-target.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "Task to build and install header and libs into sdk"
 LICENSE = "MIT"
 PR = "r5"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 MULTIMEDIA = ""
 

--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-multimedia.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-multimedia.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "Task to add multimedia related packages"
 LICENSE = "MIT"
 PR = "r13"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 MULTIMEDIA = ""
 

--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-qte-sdk-host.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-qte-sdk-host.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "Task to add Qt embedded related sources into the sdk"
 LICENSE = "MIT"
 PR = "r6"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 QT4_DEMOS = "\
     ${@base_conditional('ARAGO_QT_PROVIDER', 'qt4-embedded-gles', 'quick-playground-src', '', d)} \

--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-qte.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-qte.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "Task to add Qt embedded related packages"
 LICENSE = "MIT"
 PR = "r12"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 QT4_DEMOS = "\
     qt4-embedded-examples \

--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-toolchain-tisdk-target.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-toolchain-tisdk-target.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "Task to build and install header and libs into the sdk"
 LICENSE = "MIT"
 PR = "r7"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 QT_TOOLCHAIN_TARGET = "\
     packagegroup-arago-qte-toolchain-target \

--- a/meta-arago-extras/recipes-core/packagegroups/packagegroup-arago-qte-toolchain-target.bb
+++ b/meta-arago-extras/recipes-core/packagegroups/packagegroup-arago-qte-toolchain-target.bb
@@ -3,9 +3,9 @@ LICENSE = "MIT"
 
 PR = "r8"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 QT4_SGX_SUPPORT = "\
         libqt-embeddedopengl4-dev \

--- a/meta-arago-extras/recipes-core/packagegroups/packagegroup-arago-standalone-sdk-target.bb
+++ b/meta-arago-extras/recipes-core/packagegroups/packagegroup-arago-standalone-sdk-target.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "Target packages for the standalone SDK"
 PR = "r7"
 LICENSE = "MIT"
 
-inherit packagegroup
-
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
 
 RDEPENDS_${PN} = "\
     libgcc \


### PR DESCRIPTION
This change is required to fix following build time error:
ERROR: Please ensure recipe *.bb sets PACKAGE_ARCH before inherit
packagegroup

Signed-off-by: Fahad Arslan Fahad_Arslan@mentor.com
