### PR TITLE
layer.conf: Fix error about empty srcipk for kernels recipes

### DIFF
--- a/meta-arago-distro/conf/layer.conf
+++ b/meta-arago-distro/conf/layer.conf
@@ -34,3 +34,5 @@ SIGGEN_EXCLUDERECIPES_ABISAFE += " \
 "
 
 BBMASK = " meta-arago/meta-arago-distro/recipes-core/psplash/ "
+CREATE_SRCIPK = "0"
+INHERIT += " sourceipk "


### PR DESCRIPTION
Disable sourceipk generation but inherit the required class (sourceipk)
Without these changes, many "foo seems to be empty" errors are produced
for the do_create_srcipk task.

Signed-off-by: Valentin Sitdikov <valentin_sitdikov@mentor.com>
Acked-by: Cedric Hombourger <cedric_hombourger@mentor.com>