### PR TITLE
packagegroup-arago-tisdk-addons: Remove parted from UTILS_append_k3

### DIFF
--- a/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-addons.bb
+++ b/meta-arago-distro/recipes-core/packagegroups/packagegroup-arago-tisdk-addons.bb
@@ -71,7 +71,6 @@ UTILS_append_omap-a15 = " mmc-utils \
 
 UTILS_append_k3 = " mmc-utils \
                     can-utils \
-                    parted \
                     switch-config \
                     irqbalance \
                     jailhouse \


### PR DESCRIPTION
* Parted is GPLV3 licensed. When MEL builds without GPLV3, build
  fails on parted missing. Parted is not needed on target so
  removed it from UTILS_append_k3.

Signed-off-by: ahsann <noor_ahsan@mentor.com>